### PR TITLE
Add dependencies and module init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+*swp
 
 
 # Byte-compiled / optimized / DLL files

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+sklearn
+pandas


### PR DESCRIPTION
Ellery, this just lets you setup locally by doing

pip install -r requirements.txt
cd api
python recommender_api.py

Right now though that crashes due to missing data.  Ideally you should add some small example to the repo.  It would make developing locally easier.